### PR TITLE
adding watch task for images

### DIFF
--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -19,6 +19,7 @@ function serve() {
     ['node_modules/bootstrap/scss/bootstrap.scss','src/scss/**/*.*css'],
     gulp.series('styles', browserSyncReload)
     );
+    gulp.watch(['src/img/**/*'], gulp.series('images', browserSyncReload));
 }
 
 gulp.task('serve', serve);


### PR DESCRIPTION
This PR adds a line from the icj-project-rig into this template to watch the src/img folder for new images and then process them. (instead of forcing a gulp dev restart)